### PR TITLE
Add MCP tool support

### DIFF
--- a/src/openai/types/beta/__init__.py
+++ b/src/openai/types/beta/__init__.py
@@ -16,6 +16,7 @@ from .thread_update_params import ThreadUpdateParams as ThreadUpdateParams
 from .assistant_list_params import AssistantListParams as AssistantListParams
 from .assistant_tool_choice import AssistantToolChoice as AssistantToolChoice
 from .code_interpreter_tool import CodeInterpreterTool as CodeInterpreterTool
+from .mcp_tool import McpTool as McpTool
 from .assistant_stream_event import AssistantStreamEvent as AssistantStreamEvent
 from .file_search_tool_param import FileSearchToolParam as FileSearchToolParam
 from .assistant_create_params import AssistantCreateParams as AssistantCreateParams
@@ -31,3 +32,4 @@ from .assistant_tool_choice_function_param import AssistantToolChoiceFunctionPar
 from .assistant_response_format_option_param import (
     AssistantResponseFormatOptionParam as AssistantResponseFormatOptionParam,
 )
+from .mcp_tool_param import McpToolParam as McpToolParam

--- a/src/openai/types/beta/assistant_tool.py
+++ b/src/openai/types/beta/assistant_tool.py
@@ -7,9 +7,11 @@ from ..._utils import PropertyInfo
 from .function_tool import FunctionTool
 from .file_search_tool import FileSearchTool
 from .code_interpreter_tool import CodeInterpreterTool
+from .mcp_tool import McpTool
 
 __all__ = ["AssistantTool"]
 
 AssistantTool: TypeAlias = Annotated[
-    Union[CodeInterpreterTool, FileSearchTool, FunctionTool], PropertyInfo(discriminator="type")
+    Union[CodeInterpreterTool, FileSearchTool, FunctionTool, McpTool],
+    PropertyInfo(discriminator="type"),
 ]

--- a/src/openai/types/beta/assistant_tool_param.py
+++ b/src/openai/types/beta/assistant_tool_param.py
@@ -8,7 +8,13 @@ from typing_extensions import TypeAlias
 from .function_tool_param import FunctionToolParam
 from .file_search_tool_param import FileSearchToolParam
 from .code_interpreter_tool_param import CodeInterpreterToolParam
+from .mcp_tool_param import McpToolParam
 
 __all__ = ["AssistantToolParam"]
 
-AssistantToolParam: TypeAlias = Union[CodeInterpreterToolParam, FileSearchToolParam, FunctionToolParam]
+AssistantToolParam: TypeAlias = Union[
+    CodeInterpreterToolParam,
+    FileSearchToolParam,
+    FunctionToolParam,
+    McpToolParam,
+]

--- a/src/openai/types/beta/mcp_tool.py
+++ b/src/openai/types/beta/mcp_tool.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Optional, List, Dict, Union
+from typing_extensions import Literal, TypeAlias
+
+from ..._models import BaseModel
+
+__all__ = [
+    "McpTool",
+    "McpAllowedTools",
+    "McpAllowedToolsMcpAllowedToolsFilter",
+    "McpRequireApproval",
+    "McpRequireApprovalMcpToolApprovalFilter",
+    "McpRequireApprovalMcpToolApprovalFilterAlways",
+    "McpRequireApprovalMcpToolApprovalFilterNever",
+]
+
+
+class McpAllowedToolsMcpAllowedToolsFilter(BaseModel):
+    tool_names: Optional[List[str]] = None
+    """List of allowed tool names."""
+
+
+McpAllowedTools: TypeAlias = Union[List[str], McpAllowedToolsMcpAllowedToolsFilter, None]
+
+
+class McpRequireApprovalMcpToolApprovalFilterAlways(BaseModel):
+    tool_names: Optional[List[str]] = None
+    """List of tools that require approval."""
+
+
+class McpRequireApprovalMcpToolApprovalFilterNever(BaseModel):
+    tool_names: Optional[List[str]] = None
+    """List of tools that do not require approval."""
+
+
+class McpRequireApprovalMcpToolApprovalFilter(BaseModel):
+    always: Optional[McpRequireApprovalMcpToolApprovalFilterAlways] = None
+    """A list of tools that always require approval."""
+
+    never: Optional[McpRequireApprovalMcpToolApprovalFilterNever] = None
+    """A list of tools that never require approval."""
+
+
+McpRequireApproval: TypeAlias = Union[McpRequireApprovalMcpToolApprovalFilter, Literal["always", "never"], None]
+
+
+class McpTool(BaseModel):
+    server_label: str
+    """A label for this MCP server, used to identify it in tool calls."""
+
+    server_url: str
+    """The URL for the MCP server."""
+
+    type: Literal["mcp"]
+    """The type of the MCP tool. Always `mcp`."""
+
+    allowed_tools: Optional[McpAllowedTools] = None
+    """List of allowed tool names or a filter object."""
+
+    headers: Optional[Dict[str, str]] = None
+    """Optional HTTP headers to send to the MCP server.
+
+    Use for authentication or other purposes.
+    """
+
+    require_approval: Optional[McpRequireApproval] = None
+    """Specify which of the MCP server's tools require approval."""
+

--- a/src/openai/types/beta/mcp_tool_param.py
+++ b/src/openai/types/beta/mcp_tool_param.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Union
+from typing_extensions import Literal, Required, TypedDict, TypeAlias
+
+__all__ = [
+    "McpToolParam",
+    "McpAllowedTools",
+    "McpAllowedToolsMcpAllowedToolsFilter",
+    "McpRequireApproval",
+    "McpRequireApprovalMcpToolApprovalFilter",
+    "McpRequireApprovalMcpToolApprovalFilterAlways",
+    "McpRequireApprovalMcpToolApprovalFilterNever",
+]
+
+
+class McpAllowedToolsMcpAllowedToolsFilter(TypedDict, total=False):
+    tool_names: List[str]
+    """List of allowed tool names."""
+
+
+McpAllowedTools: TypeAlias = Union[List[str], McpAllowedToolsMcpAllowedToolsFilter]
+
+
+class McpRequireApprovalMcpToolApprovalFilterAlways(TypedDict, total=False):
+    tool_names: List[str]
+    """List of tools that require approval."""
+
+
+class McpRequireApprovalMcpToolApprovalFilterNever(TypedDict, total=False):
+    tool_names: List[str]
+    """List of tools that do not require approval."""
+
+
+class McpRequireApprovalMcpToolApprovalFilter(TypedDict, total=False):
+    always: McpRequireApprovalMcpToolApprovalFilterAlways
+    """A list of tools that always require approval."""
+
+    never: McpRequireApprovalMcpToolApprovalFilterNever
+    """A list of tools that never require approval."""
+
+
+McpRequireApproval: TypeAlias = Union[McpRequireApprovalMcpToolApprovalFilter, Literal["always", "never"]]
+
+
+class McpToolParam(TypedDict, total=False):
+    server_label: Required[str]
+    """A label for this MCP server, used to identify it in tool calls."""
+
+    server_url: Required[str]
+    """The URL for the MCP server."""
+
+    type: Required[Literal["mcp"]]
+    """The type of the MCP tool. Always `mcp`."""
+
+    allowed_tools: Optional[McpAllowedTools]
+    """List of allowed tool names or a filter object."""
+
+    headers: Optional[Dict[str, str]]
+    """Optional HTTP headers to send to the MCP server.
+
+    Use for authentication or other purposes.
+    """
+
+    require_approval: Optional[McpRequireApproval]
+    """Specify which of the MCP server's tools require approval."""
+

--- a/tests/api_resources/beta/test_assistants.py
+++ b/tests/api_resources/beta/test_assistants.py
@@ -29,6 +29,14 @@ class TestAssistants:
         assert_matches_type(Assistant, assistant, path=["response"])
 
     @parametrize
+    def test_method_create_with_mcp_tool(self, client: OpenAI) -> None:
+        assistant = client.beta.assistants.create(
+            model="gpt-4o",
+            tools=[{"type": "mcp", "server_label": "test", "server_url": "https://example.com"}],
+        )
+        assert_matches_type(Assistant, assistant, path=["response"])
+
+    @parametrize
     def test_method_create_with_all_params(self, client: OpenAI) -> None:
         assistant = client.beta.assistants.create(
             model="gpt-4o",
@@ -259,6 +267,14 @@ class TestAsyncAssistants:
     async def test_method_create(self, async_client: AsyncOpenAI) -> None:
         assistant = await async_client.beta.assistants.create(
             model="gpt-4o",
+        )
+        assert_matches_type(Assistant, assistant, path=["response"])
+
+    @parametrize
+    async def test_method_create_with_mcp_tool(self, async_client: AsyncOpenAI) -> None:
+        assistant = await async_client.beta.assistants.create(
+            model="gpt-4o",
+            tools=[{"type": "mcp", "server_label": "test", "server_url": "https://example.com"}],
         )
         assert_matches_type(Assistant, assistant, path=["response"])
 


### PR DESCRIPTION
## Summary
- include MCP tool definitions for beta types
- export MCP types and add to union definitions
- remove extraneous dev dependency updates
- add assistant MCP tool tests

## Testing
- `python -m pytest -k 'mcp_tool' -q` *(fails: connection refused)*